### PR TITLE
fix(godotdoc): filter completions by what user has typed

### DIFF
--- a/plugin/gdscript-extended-lsp.lua
+++ b/plugin/gdscript-extended-lsp.lua
@@ -19,7 +19,7 @@ vim.api.nvim_create_user_command("GodotDoc",
             -- Completion
             for _, class in ipairs(require("gdscript-extended-lsp").get_classes()) do
                 -- Find only classes that begin with current arg
-                if string.match(class, arg) then
+                if string.match(class:lower(), arg:lower()) then
                     table.insert(comp, class)
                 end
             end

--- a/plugin/gdscript-extended-lsp.lua
+++ b/plugin/gdscript-extended-lsp.lua
@@ -7,13 +7,23 @@ vim.api.nvim_create_user_command("GodotDoc",
     end, {
         nargs = "+",
         complete = function(arg_lead, cmd_line, cursor_pos)
-            local split_cmd = vim.split(cmd_line, " ", { trimempty = true })
-            -- Completion
-            if #split_cmd == 1 then
-                return require("gdscript-extended-lsp").get_classes()
+            local split_cmd = vim.split(cmd_line, " ", { })
+            -- Only offer completions for second word
+            if #split_cmd ~= 2 then
+                return {}
             end
-            -- Default to empty
-            return {}
+
+            -- Get current arg
+            local arg = string.gsub(cmd_line, ".* ", "^")
+            local comp = {}
+            -- Completion
+            for _, class in ipairs(require("gdscript-extended-lsp").get_classes()) do
+                -- Find only classes that begin with current arg
+                if string.match(class, arg) then
+                    table.insert(comp, class)
+                end
+            end
+            return comp
         end
     }
 )


### PR DESCRIPTION
Now when the user types, eg., ":GodotDoc N" and triggers autocompletion the results returned will just be the classes starting with "N".