### PR TITLE
feat(fzf-lua): add fzf-lua as picker option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ While viewing documentation in Neovim, use `gf` to open the class under the curs
     close = { "q", "<Esc>" }, -- Keymap for closing the documentation
   },
   floating_win_size = 0.8, -- Floating window size
-  picker = "telescope" -- Options : "telescope", "snacks"
+  picker = "telescope" -- Options : "telescope", "snacks", "fzf-lua"
 }
 ```
 

--- a/lua/gdscript-extended-lsp/init.lua
+++ b/lua/gdscript-extended-lsp/init.lua
@@ -417,6 +417,8 @@ function M.pick()
         picker.telescope()
     elseif M.options.picker == "snacks" then
         picker.snacks()
+    elseif M.options.picker == "fzf-lua" then
+        picker.fzf_lua()
     else
         vim.notify("'" .. M.options.picker .. "' Not supported", vim.log.levels.ERROR)
     end

--- a/lua/gdscript-extended-lsp/picker.lua
+++ b/lua/gdscript-extended-lsp/picker.lua
@@ -92,4 +92,15 @@ function M.telescope()
     end
 end
 
+function M.fzf_lua()
+    local opts = {}
+    opts.actions = {
+        ["default"] = function(selected)
+            require("gdscript-extended-lsp").request_doc_class(selected[1])
+        end,
+    }
+    opts.winopts = { title = "Godot Classes" }
+    require("fzf-lua").fzf_exec(require("gdscript-extended-lsp").get_classes(), opts)
+end
+
 return M


### PR DESCRIPTION
Support using fzf-lua (https://github.com/ibhagwan/fzf-lua) as an option for picking a Godot class to read the docs of.