### PR TITLE
Fix for error when opening doc buffer.

### DIFF
--- a/lua/gdscript-extended-lsp/init.lua
+++ b/lua/gdscript-extended-lsp/init.lua
@@ -140,7 +140,7 @@ function M.request_doc_class(symbol)
 
         -- After the LSP attaches, send a declaration request
         vim.defer_fn(function()
-            client:request(
+            client.request(
                 "textDocument/declaration",
                 {
                     position = { character = 9, line = 0 },


### PR DESCRIPTION
client.request was being called with the : operator causing it to fail due to incorrect parameters.